### PR TITLE
Use lowercase name for Bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ObjectId.js",
+  "name": "objectid.js",
   "version": "1.0.0",
   "homepage": "https://github.com/DeadHeadRussell/ObjectId.js",
   "authors": [


### PR DESCRIPTION
Bower requires lowercase names, but this file specifies a camel cased name. This can cause case-sensitivity issues when tools like Brunch try to resolve dependencies. Can you update this and release a 1.0.1 on Bower? 

And btw - thanks for getting this package on Bower in the first place!
